### PR TITLE
Allow passing region and source_ami via cli with -var "region=eu-west…

### DIFF
--- a/foxpass_vpn.json
+++ b/foxpass_vpn.json
@@ -1,14 +1,16 @@
 {
   "variables":{
     "aws_access_key":"",
-    "aws_secret_key":""
+    "aws_secret_key":"",
+    "region":"us-west-2",
+    "source_ami":"ami-9abea4fb"
   },
   "builders":[
     {
       "access_key":"{{user `aws_access_key`}}",
       "secret_key":"{{user `aws_secret_key` }}",
-      "region":"us-west-2",
-      "source_ami":"ami-6635cd06",
+      "region":"{{user `region`}}",
+      "source_ami":"{{user `source_ami`}}",
       "type":"amazon-ebs",
       "instance_type":"t2.nano",
       "ami_name":"foxpass-ipsec-vpn {{timestamp}}",


### PR DESCRIPTION
Here you go Aren... 

You can now pass region and source ami on the command line, ie

`packer build -var 'region=eu-west-1' -var 'source_ami=ami-8328bbf0' foxpass_vpn.json`
