### PR TITLE
Update jinja2 because CVE-2024-56326

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 boto3==1.34.3
 ifaddr==0.1.6
 iptools==0.7.0
-jinja2==3.1.4
+jinja2==3.1.5
 pyasn1==0.4.8
 python-hosts==1.0.0
 pyOpenSSL==19.1.0


### PR DESCRIPTION
## Description of the change

We need update jinja2 version because a vulnerability CVE-2024-56326

## Type of change
- [X] Bug fix
- [ ] New feature
